### PR TITLE
Verwende GitHub-Pages

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -1343,8 +1343,8 @@ class FlurstuecksFinderNRW:
     def CheckCache(self):
         """ Checks if an internet connection is available and if the github file
         has been changed  """
-        url_md5 = 'https://raw.githubusercontent.com/kreis-viersen/katasteraemter-gemarkungen-fluren-nrw/main/data/katasteraemter-gemarkungen-fluren-nrw.json.md5'
-        url_json = 'https://raw.githubusercontent.com/kreis-viersen/katasteraemter-gemarkungen-fluren-nrw/main/data/katasteraemter-gemarkungen-fluren-nrw.json'
+        url_md5 = 'https://kreis-viersen.github.io/katasteraemter-gemarkungen-fluren-nrw/data/katasteraemter-gemarkungen-fluren-nrw.json.md5'
+        url_json = 'https://kreis-viersen.github.io/katasteraemter-gemarkungen-fluren-nrw/data/katasteraemter-gemarkungen-fluren-nrw.json'
         masterfile = os.path.join(self.cache_dir, 'katasteraemter-gemarkungen-fluren-nrw.json')
         response_md5 = requests.get(url_md5)
         hash_md5 = None


### PR DESCRIPTION
`raw.githubusercontent.com` ist nicht zum Hosten von statischen Dateien gedacht, verwende statt dessen GitHub-Pages.