### PR TITLE
Verwende Parameter "propertyname" für NRW-WFS-Request

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -587,7 +587,7 @@ class FlurstuecksFinderNRW:
                     param['propertyname'] = 'FLSTNRZAE,FLSTNRNEN,FLSTKENNZ'
                 else:
                     param['typename'] = 'ave:FlurstueckPunkt'
-                    # param['propertyname'] = 'ave:flstnrzae,ave:flstnrnen,ave:flstkennz'
+                    param['propertyname'] = 'ave:flstnrnen'
                 flur_id = None
                 gem_nr = kwargs["gem_id"]
                 flur_nr = kwargs["flur_nr"]


### PR DESCRIPTION
Wenn nur `ave:flstnrnen` für den Parameter `propertyname `angegeben wird, kommen alle gewünschten Attribute mit und optionale Attribute werden nicht mitgeliefert (spart ca. 20% der Datenmenge).

Beispiel:

**mit `propertyname=ave:flstnrnen`**

https://www.wfs.nrw.de/geobasis/wfs_nw_alkis_vereinfacht?propertyname=ave:flstnrnen&SERVICE=WFS&REQUEST=GetFeature&VERSION=1.1.0&TYPENAME=ave:FlurstueckPunkt&SRSNAME=urn:ogc:def:crs:EPSG::25832&FILTER=%3CFilter%20xmlns%3D%22http://www.opengis.net/ogc%22%20xmlns:ave%3D%22http://repository.gdi-de.org/schemas/adv/produkt/alkis-vereinfacht/2.0%22%3E%3CAnd%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eave:gemaschl%3C/PropertyName%3E%3CLiteral%3E054951%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eave:flurschl%3C/PropertyName%3E%3CLiteral%3E054951003%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/And%3E%3C/Filter%3E&NAMESPACE=xmlns(ave%3Dhttp://repository.gdi-de.org/schemas/adv/produkt/alkis-vereinfacht/2.0)


**ohne Parameter `propertyname`**

https://www.wfs.nrw.de/geobasis/wfs_nw_alkis_vereinfacht?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.1.0&TYPENAME=ave:FlurstueckPunkt&SRSNAME=urn:ogc:def:crs:EPSG::25832&FILTER=%3CFilter%20xmlns%3D%22http://www.opengis.net/ogc%22%20xmlns:ave%3D%22http://repository.gdi-de.org/schemas/adv/produkt/alkis-vereinfacht/2.0%22%3E%3CAnd%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eave:gemaschl%3C/PropertyName%3E%3CLiteral%3E054951%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eave:flurschl%3C/PropertyName%3E%3CLiteral%3E054951003%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/And%3E%3C/Filter%3E&NAMESPACE=xmlns(ave%3Dhttp://repository.gdi-de.org/schemas/adv/produkt/alkis-vereinfacht/2.0)