### PR TITLE
Füge Parameter "Maßstab/Scale" zu TIM-Online hinzu

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -1335,7 +1335,8 @@ class FlurstuecksFinderNRW:
                     url = 'https://www.tim-online.nrw.de/tim-online2/?'
                     param = {'bg': 'alkis',
                              'center': f'{x},{y}',
-                             'icon': 'true'
+                             'icon': 'true',
+                             'scale': int(self.canvas.scale())
                              }
                 url = url + urllib.parse.unquote_plus(urllib.parse.urlencode(param))
                 webbrowser.open_new_tab(url)


### PR DESCRIPTION
Übernimmt den QGIS Canvas-Maßstab für TIM-Online. 
So wird sichergestellt, dass das Flurstück immer gut erkennbar ist.
Ohne Scale Parameter:
![image](https://user-images.githubusercontent.com/73645103/143564765-046252a5-36fe-4a7a-a8d4-782ed5dcba34.png)

Mit Scale Parameter:
![image](https://user-images.githubusercontent.com/73645103/143564711-07a2edff-f880-4e1f-bdf6-8008726f9540.png)
