### PR TITLE
Verwende QgsBlockingNetworkRequest anstatt requests

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -73,7 +73,6 @@ from .start_josm import *
 qgis_version = Qgis.QGIS_VERSION.split("-")[0]
 # For future releases to catch version differences
 # QgsMessageLog.logMessage('Nachricht', 'Flurstücksfinder NRW', level=Qgis.Info)
-# Potentially proxy config
 
 # ---------------------------------------------------------------------------- #
 # Class to initialize the plugin GUIs                                          #


### PR DESCRIPTION
Das ist die empfohlene Vorgehensweise, Vorteile:

- Die Requests werden in den Logs bei den QGIS-Diagnose-/Entwicklerwerkzeugen angezeigt.
<img src="https://user-images.githubusercontent.com/20856381/144826024-4edf85e1-3882-41e2-b567-0c80c92bc4af.png" width="500"/>

- Das Proxy-Handling wird mit übernommen.

