### PR TITLE
Rufe verfügbare CRS nur beim Start und Wechsel des WFS ab

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -544,7 +544,6 @@ class FlurstuecksFinderNRW:
         """ Checks the CRS """
         crs_list = {}
         crs = None
-        results = []
 
         # Checks current CRS
         crs = QgsProject.instance().crs().authid()


### PR DESCRIPTION
Bisher wird mit jedem Aufruf von `CheckCRS` ein GetCapabilites-Request an den WFS abgesetzt um die verfügbaren CRS zu erhalten. Dies führt zu mehr GetCapabilites-Requests als nötig.

Mit diesem PR wird der Teil mit dem GetCapabilites-Request aus `CheckCRS` in eine eigene Funktion `GetCRS` ausgelagert und diese nur beim Start des Plugins und Wechsel des WFS (Auswahl des Gebietes über die Radiobuttons im Tab _Einstellungen_) aufgerufen.