### PR TITLE
Möglicher Fix für zu viele Requests

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -865,9 +865,7 @@ class FlurstuecksFinderNRW:
                 idx2 = self.dockwidget.cmb_flur_nr.findText(
                     flur, Qt.MatchFixedString)
                 if idx2 != -1:
-                    self.dockwidget.cmb_flur_nr.blockSignals(True)
                     self.dockwidget.cmb_flur_nr.setCurrentIndex(idx2)
-                    self.dockwidget.cmb_flur_nr.blockSignals(False)
 
             if flst != self.dockwidget.cmb_flurstueck.currentText():
                 idx3 = self.dockwidget.cmb_flurstueck.findText(


### PR DESCRIPTION
Überarbeitet die Funktion zum Abgleichen des Textfeld (Gemarkung-Flur-Flurstück) und der Comboboxen.

Verschiebt self.mouse_click.canvasClicked.connect in die Funktion __init__.
Damit könnte verhindert werden, dass die Aktion, die an das Signal canvasClicked gebunden ist, mehrfach an das Maptool "mouse_click" gebunden wird.
Möglicher Fix für #14