### PR TITLE
Fix AttributeError: 'QComboBox' object has no attribute 'setPlaceholderText' 

### DIFF
--- a/flurstuecks_finder_nrw_dockwidget_base.ui
+++ b/flurstuecks_finder_nrw_dockwidget_base.ui
@@ -509,9 +509,6 @@
              <property name="minimumContentsLength">
               <number>35</number>
              </property>
-             <property name="placeholderText">
-              <string/>
-             </property>
              <property name="frame">
               <bool>true</bool>
              </property>


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/20856381/152301493-fdd28b5f-6f10-4a58-8cf8-4ad6287a75e0.png" width="600" />
