### PR TITLE
Verwende Feldlänge 1000 für 'LAGEBEZTXT'

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -1021,7 +1021,10 @@ class FlurstuecksFinderNRW:
                 geometry = 'geometrie'
             fields = QgsFields()
             for fieldname in fieldnames:
-                fields.append(QgsField(fieldname, QVariant.String, '', 100, 0))
+                fieldlength = 100
+                if fieldname == 'LAGEBEZTXT':
+                    fieldlength = 1000
+                fields.append(QgsField(fieldname, QVariant.String, '', fieldlength, 0))
             gml = None
             gml = QgsGml(typename, geometry, fields)
             wfs_request = gml.getFeaturesUri(url)


### PR DESCRIPTION
**Fix:** 
KVIE WFS - Flurstück _3378-34-19_ - kann nicht gefunden werden

Flurstück _3378-34-19_ hat 254 Zeichen für `LAGEBEZTXT`:

![grafik](https://user-images.githubusercontent.com/20856381/152775149-cc23ea7a-85b7-48fb-9499-74c22161a1b1.png)


GetFeature-Request:
https://geoservices.krzn.de/security-proxy/services/wfs_kvie_alkis_adv_vereinfacht?service=WFS&version=2.0.0&request=GetFeature&srsname=urn:ogc:def:crs:EPSG::25832&typename=gis:alkis_adv_flurstueck&filter=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CValueReference%3EFLSTKENNZ%3C/ValueReference%3E%3CLiteral%3E05337803400019______%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E