### PR TITLE
Fix Rechtsklick für Reiter Flurstückinfos

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -330,6 +330,12 @@ class FlurstuecksFinderNRW:
             self.dockwidget.btn_open_portal.setToolTip(
                 'Öffnet die Flurstücks-Position in TIM-Online')
 
+        # QTableWidget custom action when right-clicking with the mouse, calls a function
+        self.dockwidget.tbl_flurstueck.setContextMenuPolicy(
+            Qt.CustomContextMenu)
+        self.dockwidget.tbl_flurstueck.customContextMenuRequested.connect(
+            self.CopyTableCell)
+
 # ---------------------------------------------------------------------------- #
 
     def onClosePlugin(self):
@@ -1377,12 +1383,6 @@ class FlurstuecksFinderNRW:
                     self.FillComboBoxGemarkung()
         else:
             self.FillComboBoxGemarkung()
-
-        # QTableWidget custom action when right-clicking with the mouse, calls a function
-        self.dockwidget.tbl_flurstueck.setContextMenuPolicy(
-            Qt.CustomContextMenu)
-        self.dockwidget.tbl_flurstueck.customContextMenuRequested.connect(
-            self.CopyTableCell)
 
     def run(self):
         """ Method to run the plugin """

--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -1257,12 +1257,6 @@ class FlurstuecksFinderNRW:
                 QHeaderView.ResizeToContents)
             self.dockwidget.tbl_flurstueck.horizontalHeader().setSectionResizeMode(0,QHeaderView.Stretch)
 
-            # Custom action when right-clicking with the mouse, calls a function
-            self.dockwidget.tbl_flurstueck.setContextMenuPolicy(
-                Qt.CustomContextMenu)
-            self.dockwidget.tbl_flurstueck.customContextMenuRequested.connect(
-                self.CopyTableCell)
-
     def CopyTableCell(self):
         """ Function is called when a cell has been right-clicked on """
         idx = self.dockwidget.tbl_flurstueck.currentRow()
@@ -1383,6 +1377,12 @@ class FlurstuecksFinderNRW:
                     self.FillComboBoxGemarkung()
         else:
             self.FillComboBoxGemarkung()
+
+        # QTableWidget custom action when right-clicking with the mouse, calls a function
+        self.dockwidget.tbl_flurstueck.setContextMenuPolicy(
+            Qt.CustomContextMenu)
+        self.dockwidget.tbl_flurstueck.customContextMenuRequested.connect(
+            self.CopyTableCell)
 
     def run(self):
         """ Method to run the plugin """


### PR DESCRIPTION
Verschiebe das connecten nach `StartupRoutine`, weil sonst jedes Mal, wenn ein Flurstück aufgerufen wird, connected wird. Mit der Folge, dass wenn z.B. 10 Flurstücke aufgerufen wurden, der Wert bei Rechtsklick 10x in die Zwischenablage kopiert wurde.