### PR TITLE
Füge weiteres Suchfeld für vollständiges Flurstückskennzeichen hinzu

### DIFF
--- a/flurstuecks_finder_nrw_dockwidget_base.ui
+++ b/flurstuecks_finder_nrw_dockwidget_base.ui
@@ -284,7 +284,69 @@
               <enum>Qt::LeftToRight</enum>
              </property>
              <property name="placeholderText">
-              <string>Flurstückskennzeichen</string>
+              <string>Gemarkung-Flur-Flurstück</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QPushButton" name="btn_suchen_flstkennzlang">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>12</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flurstück suchen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="resources.qrc">
+               <normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>15</width>
+               <height>15</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QPushButton" name="btn_suchen_alkis_id">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>12</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flurstück suchen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="resources.qrc">
+               <normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>15</width>
+               <height>15</height>
+              </size>
              </property>
             </widget>
            </item>
@@ -322,7 +384,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="2" column="0">
             <widget class="QLineEdit" name="txt_alkis_id">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -341,34 +403,22 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
-            <widget class="QPushButton" name="btn_suchen_alkis_id">
+           <item row="3" column="0">
+            <widget class="QLineEdit" name="txt_flstkennzlang">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-              </font>
-             </property>
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flurstück suchen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flurstückskennzeichen eintragen.&lt;br&gt;Beginnt mit 05**&lt;br&gt;z.B. 05105900200942______&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string/>
              </property>
-             <property name="icon">
-              <iconset resource="resources.qrc">
-               <normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</normaloff>:/plugins/flurstuecks_finder_nrw/icons/search.png</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>15</width>
-               <height>15</height>
-              </size>
+             <property name="placeholderText">
+              <string>Flurstückskennzeichen</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Bisher gab es nur ein Suchfeld für die verkürzte Variante "Gemarkung-Flur-Flurstück".  Der User erwartet bei Flurstückskennzeichen u.U. die vollständige Kennung (20 Zeichen). Ermöglicht auch das copy&paste des vollständigen Kennzeichens für die Suche.