### PR TITLE
Minimum QGIS Version 3.16.14

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -4,7 +4,7 @@
 
 [general]
 name=Flurstücksfinder NRW
-qgisMinimumVersion=3.16
+qgisMinimumVersion=3.16.14
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
 version=1.1.0
 author=Kreis Viersen


### PR DESCRIPTION
Frühere Versionen sind nicht getestet und wir können nicht sicher sein, dass das Plugin mit älteren Versionen läuft.

ref https://github.com/kreis-viersen/flurstuecksfinder-nrw/issues/45