### PR TITLE
Entferne führende und nachlaufende Leerzeichen in Suchfeldern

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -988,9 +988,9 @@ class FlurstuecksFinderNRW:
     def SearchFlurstueck(self, art, mouse_click):
         """ The actual search function, which uses either Flurstückskennzeichen (Gemarkung-Flur-Flurstück), ALKIS ID or Flurstückskennzeichen"""
         if art in ['flstkennz', 'alkisid', 'flstkennzlang']:
-            text_alkis_id = self.dockwidget.txt_alkis_id.text()
-            text_flstkennz = self.dockwidget.txt_gemarkung_flur_flurstueck.text()
-            text_flstkennzlang = self.dockwidget.txt_flstkennzlang.text()
+            text_alkis_id = self.dockwidget.txt_alkis_id.text().strip()
+            text_flstkennz = self.dockwidget.txt_gemarkung_flur_flurstueck.text().strip()
+            text_flstkennzlang = self.dockwidget.txt_flstkennzlang.text().strip()
             if self.dockwidget.rb_group.checkedButton().text() in ['Stadt Krefeld', 'Kreis Wesel', 'Kreis Viersen', 'Kreis Kleve']:
                 gem_id = text_flstkennz.split("-")[0]
                 for k, v in self.katasterdaten.items():

--- a/metadata.txt
+++ b/metadata.txt
@@ -25,7 +25,7 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=v1.1.3:
-          - Leerzeichen am Anfang und Ende der Eingabefelder (z.B. Gemarkung-Flur-Flurstück) entfernt
+          - Entferne etwaige überflüssige Leerzeichen eingegebener IDs
           v1.1.2:
           - Überschrift im Einstellungs Reiter erweitert
           v1.1.1:

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Flurstücksfinder NRW
 qgisMinimumVersion=3.16.14
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.1.2
+version=1.1.3
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,9 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.1.2:
+changelog=v1.1.3:
+          - Leerzeichen am Anfang und Ende der Eingabefelder (z.B. Gemarkung-Flur-Flurstück) entfernt
+          v1.1.2:
           - Überschrift im Einstellungs Reiter erweitert
           v1.1.1:
           - Verbessere Links auf Geoportal Niederrhein und TIM-online


### PR DESCRIPTION
Falls der Nutzer sich aus Versehen vertippt und ein Leerzeichen am Anfang oder Ende des jeweiligen Eingabefelds gesetzt hat, wird dieses entfernt.
So wird verhindert, dass eine ansonsten korrekte Eingabe wegen eines Leerzeichen im Strings abgebrochen wird.