### PR TITLE
Ergänzung eines weiteren JOSM Verzeichnisses

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Flurstücksfinder NRW
 qgisMinimumVersion=3.16.14
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.1.3
+version=1.1.4
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,9 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.1.3:
+changelog=v1.1.4:
+          - Weiteren JOSM Pfad ergänzt
+          v1.1.3:
           - Entferne etwaige überflüssige Leerzeichen eingegebener IDs
           v1.1.2:
           - Überschrift im Einstellungs Reiter erweitert

--- a/start_josm.py
+++ b/start_josm.py
@@ -29,10 +29,10 @@ class StartJosm(object):
     def josmSearchPath(self):
         ''' Funktion zur Suche des JOSM Pfade '''
         if sys.platform.startswith("linux"):
-            app_dir = "/usr/share/josm/"
+            app_dirs = ["/usr/share/josm/"]
             cfg_dir = os.path.join(self.homepath, ".config/JOSM")
         elif sys.platform.startswith("win"):
-            app_dir = r'C:\Program Files (x86)\JOSM'
+            app_dirs = [r'C:\Program Files (x86)\JOSM', os.path.join(self.homepath, r"AppData\Local\JOSM")]
             cfg_dir = os.path.join(self.homepath, r"AppData\Roaming\JOSM")
 
         # Legt den Pfad zum JOSM Programm fest
@@ -43,10 +43,11 @@ class StartJosm(object):
         # Schleife über die JOSM Programm. Variable josm_app_path wird belegt
         # wenn der Pfad zur Datei gültig ist
         for exe in josm_exe:
-            if os.path.isfile(os.path.join(app_dir, exe)):
-                josm_app_path = os.path.join(app_dir, exe)
-            else:
-                pass
+            for app_dir in app_dirs:
+                if os.path.isfile(os.path.join(app_dir, exe)):
+                    josm_app_path = os.path.join(app_dir, exe)
+                else:
+                    pass
 
         # Legt den Pfad zur JOSM Config fest
         josm_cfg_path = None


### PR DESCRIPTION
Der JOSM-Installer für Windows legt die benötigte .exe-Datei standardmäßig im Ordner %localappdata% bzw. im nutzerspezifischen Pfad %USER%\AppData\Local\JOSM ab.
Bisher wurde nur das Verzeichnis im Ordner "Programme " berücksichtigt. 