### PR TITLE
Fix "UnboundLocalError: local variable 'results' referenced before assignment" wenn WFS-Dienst nicht verfügbar.

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -581,6 +581,11 @@ class FlurstuecksFinderNRW:
                 if results is not None:
                     results = results.getchildren()
                     results = [result.text for result in results]
+            else:
+                mb = self.ShowMessage(
+                    'Fehler', 'Konnte verfügbare KBS vom WFS nicht ermitteln!')
+                mb.setDetailedText('Die Anfrage an folgende URL schlug fehl:\n\n' + url)
+                mb.exec()
 
             if results:
                 for idx, result in enumerate(results):

--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -566,6 +566,7 @@ class FlurstuecksFinderNRW:
 
         if base_url is not None:
             url = base_url + urllib.parse.unquote_plus(urllib.parse.urlencode(param))
+            results = None
             request = QgsBlockingNetworkRequest()
             request.get(QNetworkRequest(QUrl(url)),True)
             reply = request.reply()

--- a/metadata.txt
+++ b/metadata.txt
@@ -4,9 +4,9 @@
 
 [general]
 name=Flurstücksfinder NRW
-qgisMinimumVersion=3.16.14
+qgisMinimumVersion=3.22
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.2.0
+version=1.3.0
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,10 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.2.0:
+changelog=v1.3.0:
+          - Es wird mindestens QGIS 3.22 benötigt
+          - Fehler behoben und Meldung hinzugefügt, wenn KBS des WFS nicht ermittelt werden kann
+          v1.2.0:
           - Infobox "Über Flurstücksfinder NRW" hinzugefügt
           v1.1.4:
           - Weiteren JOSM Pfad ergänzt


### PR DESCRIPTION
Heute waren die KRZN-WFS-Dienste aufgrund einer Wartung zeitweise nicht verfügbar. Dabei ist folgender Fehler aufgetreten:

![grafik](https://user-images.githubusercontent.com/20856381/196150167-86608980-8d68-4e7e-a7c1-1fa049c8299e.png)

---

Beim Metadaten-Update auch QGIS-Minimum-Version auf 3.22 gesetzt - das ist nun schon länger die aktuelle LTR-Version (das QGIS-Plugin-Repo berücksichtigt aktuell keine Patch-Versionen - so wird vermieden, dass User sich das Plugin für ein QGIS 3.16 installieren, welches nicht kompatibel mit dem Plugin ist).


 