### PR TITLE
Behebe Fehler wenn Flurstück nicht dauerhaft angezeigt wird ab QGIS 3.30 

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -29,7 +29,8 @@ try:
                            QgsMessageLog, QgsPalLayerSettings, QgsProject,
                            QgsProperty, QgsPropertyCollection,
                            QgsTextBufferSettings, QgsTextFormat,
-                           QgsVectorLayer, QgsVectorLayerSimpleLabeling)
+                           QgsVectorLayer, QgsVectorLayerSimpleLabeling,
+                           QgsWkbTypes)
     from qgis.gui import QgsHighlight, QgsMapToolEmitPoint
     from qgis.PyQt import uic
     from qgis.PyQt.QtCore import (QCoreApplication, QSize, Qt, QUrl,
@@ -1151,7 +1152,7 @@ class FlurstuecksFinderNRW:
                 FlurstuecksFinderNRW.highlight2.setFillColor(QColor(0, 0, 0, 0))
                 FlurstuecksFinderNRW.highlight2.setWidth(3)
             else:
-                self.canvas.flashGeometries([self.geom.convertToType(1)], self.layer.crs(
+                self.canvas.flashGeometries([self.geom.convertToType(QgsWkbTypes.LineGeometry)], self.layer.crs(
                 ), QColor(255, 0, 0, 255), QColor(0, 0, 0, 0), int(5), int(500))
             self.canvas.refresh()
             self.TableFlurstueckFields()

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Flurstücksfinder NRW
 qgisMinimumVersion=3.22
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.3.1
+version=1.3.2
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,9 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.3.1:
+changelog=v1.3.2:
+          - Behebe Fehler wenn Flurstück nicht dauerhaft angezeigt wird ab QGIS 3.30 
+          v1.3.1:
           - Fehlermeldung beim Laden des Plugins ergänzt, wenn ein Python-Modul nicht importiert werden kann
           v1.3.0:
           - Es wird mindestens QGIS 3.22 benötigt


### PR DESCRIPTION
Der `int` funktioniert hier ab QGIS 3.30 nicht mehr.