### PR TITLE
Hinweis wenn GetCapabilities-Dokument nicht wie erwartet

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -647,14 +647,23 @@ class FlurstuecksFinderNRW:
             request.get(QNetworkRequest(QUrl(url)), True)
             reply = request.reply()
             if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute) == 200:
-                tree = etree.parse(BytesIO(reply.content()))
-                root = tree.getroot()
-                nsmap = root.nsmap
-                if None in nsmap.keys():
-                    del nsmap[None]
-                results = root.find(
-                    ".//ows:Parameter[@name='srsName']/ows:AllowedValues", nsmap
-                )
+                try:
+                    tree = etree.parse(BytesIO(reply.content()))
+                    root = tree.getroot()
+                    nsmap = root.nsmap
+                    if None in nsmap.keys():
+                        del nsmap[None]
+                    results = root.find(
+                        ".//ows:Parameter[@name='srsName']/ows:AllowedValues", nsmap
+                    )
+                except:
+                    mb = self.ShowMessage(
+                        "Fehler", "Konnte verfügbare KBS vom WFS nicht ermitteln!"
+                    )
+                    mb.setDetailedText(
+                        "Bitte GetCapabilities-Dokument überprüfen:\n\n" + url
+                    )
+                    mb.exec()
 
                 if results is not None:
                     results = results.getchildren()

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Flurstücksfinder NRW
 qgisMinimumVersion=3.22
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.4.0
+version=1.4.1
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,9 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.4.0:
+changelog=v1.4.1:
+          - Hinweis wenn GetCapabilities-Dokument nicht wie erwartet
+          v1.4.0:
           - Verwende neue Namen für KRZN FeatureTypes
           v1.3.2:
           - Behebe Fehler wenn Flurstück nicht dauerhaft angezeigt wird ab QGIS 3.30 


### PR DESCRIPTION
Fängt einen Fehler ab, z.B. für den Fall, dass HttpStatusCodeAttribute = 200, aber statt einem GetCapabilities-Dokument kommt als Antwort eine Fehlermeldung.