### PR TITLE
Setze Layer mit Flurstückinfos 100% transparent

### DIFF
--- a/flurstuecks_finder_nrw.py
+++ b/flurstuecks_finder_nrw.py
@@ -1615,7 +1615,7 @@ class FlurstuecksFinderNRW:
                     param = {
                         "layerIDs": "200370,29105,29105flu,29106,29106flu,29107,29107flu,29108,29108flu,20070,20071",
                         "visibility": "true,true,true,true,true,true,true,true,true,true,true",
-                        "transparency": "0,0,0,0,0,0,0,0,0,0,0",
+                        "transparency": "0,0,100,0,100,0,100,0,100,0,0",
                         "marker": f"{x_poi},{y_poi}",
                         "zoomToExtent": f"{xmin},{ymin},{xmax},{ymax}",
                     }

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Flurstücksfinder NRW
 qgisMinimumVersion=3.22
 description=Find and display parcels (German State of North Rhine-Westphalia) - Flurstücksuche in NRW
-version=1.4.2
+version=1.4.3
 author=Kreis Viersen
 email=open@kreis-viersen.de
 
@@ -24,7 +24,9 @@ repository=https://github.com/kreis-viersen/flurstuecksfinder-nrw
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=v1.4.2:
+changelog=v1.4.3:
+          - Optimiere Link für das Geoportal Niederrhein
+          v1.4.2:
           - Layerauswahl für das Geoportal Niederrhein angepasst
           v1.4.1:
           - Hinweis wenn GetCapabilities-Dokument nicht wie erwartet


### PR DESCRIPTION
Behebt doppelte Nummern in großen Maßstäben:

![grafik](https://github.com/user-attachments/assets/0a24b986-a173-4b66-bda6-3b7702ed8e14)
